### PR TITLE
fix vlc crash lead to embyToLocalPlayer crash

### DIFF
--- a/utils/players.py
+++ b/utils/players.py
@@ -210,20 +210,24 @@ def stop_sec_vlc():
     stop_sec = None
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
         sock.settimeout(0.5)
-        sock.connect(('127.0.0.1', 58010))
-        while True:
-            try:
-                sock.sendall(bytes('get_time' + '\n', "utf-8"))
-                received = sock.recv(1024).decode().replace('>', '').strip()
-                # print('<-', received, '->')
-                if len(received.splitlines()) == 1 and received.isnumeric():
-                    stop_sec = received
-                    time.sleep(0.3)
-            except Exception:
-                logger.info('stop', stop_sec)
-                sock.close()
-                return stop_sec
-            time.sleep(0.1)
+        try:
+            sock.connect(('127.0.0.1', 58010))
+            while True:
+                try:
+                    sock.sendall(bytes('get_time' + '\n', "utf-8"))
+                    received = sock.recv(1024).decode().replace('>', '').strip()
+                    # print('<-', received, '->')
+                    if len(received.splitlines()) == 1 and received.isnumeric():
+                        stop_sec = received
+                        time.sleep(0.3)
+                except Exception:
+                    logger.info('stop', stop_sec)
+                    sock.close()
+                    return stop_sec
+                time.sleep(0.1)
+        except Exception:
+            logger.info('vlc crashed', 0)
+            return 0
 
 
 def stop_sec_dandan(start_sec=None, is_http=None):

--- a/utils/players.py
+++ b/utils/players.py
@@ -226,8 +226,8 @@ def stop_sec_vlc():
                     return stop_sec
                 time.sleep(0.1)
         except Exception:
-            logger.info('vlc crashed', 0)
-            return 0
+            logger.info('vlc crashed', stop_sec)
+            return stop_sec
 
 
 def stop_sec_dandan(start_sec=None, is_http=None):


### PR DESCRIPTION
vlc shall crash when media file or stream is not compatible. When happend, embyToLocalPlayer will crash cause sock can't be connected and it have no exception handle. This PR is going to add a exception handle to code that could be crash, and make application continues when vlc crash.