### PR TITLE
弹弹play enable_path 改为包含匹配

### DIFF
--- a/embyToLocalPlayer_config.ini
+++ b/embyToLocalPlayer_config.ini
@@ -140,9 +140,7 @@ exe = C:\Green\dandanplay-x64\dandanplay.exe
 port = 80
 # 若远程访问曾经启用过 Web验证，请在这里填写 api密匙，没设置则留空。
 api_key =
-# 仅当服务端路径包含以下前缀时使用弹弹播放，逗号隔开。全部文件都用弹弹播放就留空或删除。
+# 仅当服务端路径包含以下路径时使用弹弹播放，逗号隔开。全部文件都用弹弹播放就留空或删除。
 enable_path = /disk/od/TV, /disk/e/anime
-# 当服务端路径包含以下内容时使用弹弹播放，逗号隔开。与enable_path同时生效，留空代表不设置此项。
-include_path = anime, Anime
 # 通过 http 播放时，是否控制开始时间。需等待播放15秒。
 http_seek = yes

--- a/embyToLocalPlayer_config.ini
+++ b/embyToLocalPlayer_config.ini
@@ -142,5 +142,7 @@ port = 80
 api_key =
 # 仅当服务端路径包含以下前缀时使用弹弹播放，逗号隔开。全部文件都用弹弹播放就留空或删除。
 enable_path = /disk/od/TV, /disk/e/anime
+# 当服务端路径包含以下内容时使用弹弹播放，逗号隔开。与enable_path同时生效，留空代表不设置此项。
+include_path = anime, Anime
 # 通过 http 播放时，是否控制开始时间。需等待播放15秒。
 http_seek = yes

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -150,11 +150,15 @@ def use_dandan_exe_by_path(file_path):
     if not dandan or not file_path or not dandan.getboolean('enable'):
         return False
     enable_path = dandan.get('enable_path', '').replace('，', ',')
+    include_path = dandan.get('include_path', '').replace('，', ',')
     enable_path = [i.strip() for i in enable_path.split(',') if i]
-    path_match = [file_path.startswith(path) for path in enable_path]
-    if any(path_match) or not enable_path:
+    include_path = [i.strip() for i in include_path.split(',') if i]
+    enable_path_match = [file_path.startswith(path) for path in enable_path]
+    include_path_match = [path in file_path for path in include_path]
+    if (any(enable_path_match) or not enable_path) or (any(include_path_match)):
         return True
-    _logger.error(f'dandanplay {enable_path=} \n{path_match=}')
+    _logger.error(f'dandanplay {enable_path=} \n{enable_path_match=}')
+    _logger.error(f'dandanplay {include_path=} \n{include_path_match=}')
 
 
 def translate_path_by_ini(file_path):

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -150,15 +150,11 @@ def use_dandan_exe_by_path(file_path):
     if not dandan or not file_path or not dandan.getboolean('enable'):
         return False
     enable_path = dandan.get('enable_path', '').replace('，', ',')
-    include_path = dandan.get('include_path', '').replace('，', ',')
     enable_path = [i.strip() for i in enable_path.split(',') if i]
-    include_path = [i.strip() for i in include_path.split(',') if i]
-    enable_path_match = [file_path.startswith(path) for path in enable_path]
-    include_path_match = [path in file_path for path in include_path]
-    if (any(enable_path_match) or not enable_path) or (any(include_path_match)):
+    path_match = [path in file_path for path in enable_path]
+    if any(path_match) or not enable_path:
         return True
-    _logger.error(f'dandanplay {enable_path=} \n{enable_path_match=}')
-    _logger.error(f'dandanplay {include_path=} \n{include_path_match=}')
+    _logger.error(f'dandanplay {enable_path=} \n{path_match=}')
 
 
 def translate_path_by_ini(file_path):


### PR DESCRIPTION
[dandan]配置下新增了include_path配置，当服务端路径包含填写的内容时使用弹弹播放，逗号隔开。与enable_path同时生效，留空代表不设置此项