### PR TITLE
修复以管理员身份运行时的错误

### DIFF
--- a/embyToLocalPlayer_debug.bat
+++ b/embyToLocalPlayer_debug.bat
@@ -16,14 +16,14 @@ IF ERRORLEVEL ==1 GOTO ONE
 GOTO END
 :FIVE
 echo you have pressed five
-set mainCmd=python "%cd%\embyToLocalPlayer.py"
+set mainCmd=python "%~dp0embyToLocalPlayer.py"
 echo %mainCmd%
 echo already copied, pause command is "Ctrl + V"
 echo %mainCmd%|clip
 GOTO END
 :FOUR
 echo you have pressed four
-python utils/conf_helper.py
+python "%~dp0utils/conf_helper.py"
 GOTO END
 :THREE
 echo you have pressed three
@@ -33,14 +33,14 @@ GOTO END
 echo you have pressed two
 set startupVbs="%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\embyToLocalPlayer.vbs"
 rem echo "%startupVbs%"
-echo CreateObject("Wscript.Shell").Run """python"" ""%cd%\embyToLocalPlayer.py""" , 0, True > %startupVbs%
+echo CreateObject("Wscript.Shell").Run """python"" ""%~dp0embyToLocalPlayer.py""" , 0, True > %startupVbs%
 echo close this window manually
 wscript.exe ""%startupVbs%""
 exit
 GOTO END
 :ONE
 echo you have pressed one
-python embyToLocalPlayer.py
+python "%~dp0embyToLocalPlayer.py"
 :END
 
 pause

--- a/embyToLocalPlayer_debug.bat
+++ b/embyToLocalPlayer_debug.bat
@@ -1,10 +1,20 @@
 @echo OFF
+whoami /groups | find "S-1-16-12288" >nul
+if ERRORLEVEL 1 (
+  echo [ERROR] please run as administrator !!!
+  goto END
+) else (
+  goto BEGIN
+)
 :BEGIN
+if exist "%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\embyToLocalPlayer.vbs" (
+  del "%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\embyToLocalPlayer.vbs"
+)
 cls
 echo press a number
 echo 1: run in console
-echo 2: run in background and add to startup folder
-echo 3: open startup folder
+echo 2: create and run schtasks
+echo 3: stop and delete schtasks
 echo 4: path translate helper
 echo 5: copy script path to clipboard
 choice /N /C:12345 /M "press a number"%1
@@ -18,7 +28,7 @@ GOTO END
 echo you have pressed five
 set mainCmd=python "%~dp0embyToLocalPlayer.py"
 echo %mainCmd%
-echo already copied, pause command is "Ctrl + V"
+echo already copied, paste command is "Ctrl + V"
 echo %mainCmd%|clip
 GOTO END
 :FOUR
@@ -27,16 +37,19 @@ python "%~dp0utils/conf_helper.py"
 GOTO END
 :THREE
 echo you have pressed three
-explorer shell:startup
+schtasks /query /tn embyToLocalPlayer >nul 2>nul
+if not ERRORLEVEL 1 (
+  schtasks /end /tn embyToLocalPlayer
+  schtasks /delete /tn embyToLocalPlayer /f
+)
 GOTO END
 :TWO
 echo you have pressed two
-set startupVbs="%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\embyToLocalPlayer.vbs"
+set startupVbs="%~dp0embyToLocalPlayer.vbs"
 rem echo "%startupVbs%"
 echo CreateObject("Wscript.Shell").Run """python"" ""%~dp0embyToLocalPlayer.py""" , 0, True > %startupVbs%
-echo close this window manually
-wscript.exe ""%startupVbs%""
-exit
+schtasks /create /sc ONLOGON /tn embyToLocalPlayer /tr "wscript.exe \"%~dp0embyToLocalPlayer.vbs"\" /rl HIGHEST /f
+schtasks /run /tn embyToLocalPlayer
 GOTO END
 :ONE
 echo you have pressed one


### PR DESCRIPTION
管理员身份运行时，工作目录不对，导致`1 2 4 5`操作都有问题\
`%cd%`取的是工作目录，例如：\
`C:\Users\xxx>"D:\embyToLocalPlayer\embyToLocalPlayer_debug.bat"`\
`%cd%`取到的是`C:\Users\xxx`

取`bat`脚本所在目录使用`%~dp0`是更好的选择