### PR TITLE
fix: emby演员页显示错误的豆瓣评论

### DIFF
--- a/embyDouban/embyDouban.js
+++ b/embyDouban/embyDouban.js
@@ -164,6 +164,9 @@ async function getDoubanInfo(id) {
     //     return { url, rating: data.rating };
     // }
     // Fallback to search.
+    if(!id){
+        return;
+    }
     const search = await getJSON_GM(`https://movie.douban.com/j/subject_suggest?q=${id}`);
     if (search && search.length > 0 && search[0].id) {
         const abstract = await getJSON_GM(`https://movie.douban.com/j/subject_abstract?subject_id=${search[0].id}`);
@@ -223,6 +226,9 @@ async function insertDoubanMain(linkZone) {
     let imdbButton = linkZone.querySelector('a[href^="https://www.imdb"]');
     if (doubanButton || !imdbButton) { return; }
     let imdbId = imdbButton.href.match(/tt\d+/);
+    if(!imdbId){
+        return;
+    }
     if (imdbId in localStorage) {
         var doubanId = localStorage.getItem(imdbId);
     } else {


### PR DESCRIPTION
油猴插件embyDouban.js会给演员页面插入错误的豆瓣评论
 ![image](https://github.com/kjtsune/embyToLocalPlayer/assets/25526210/592351ba-86d2-4e46-98f2-e4218f404797)

修复效果
![image](https://github.com/kjtsune/embyToLocalPlayer/assets/25526210/b004f722-3553-44eb-94c5-5effb4b3fc10)
