### PR TITLE
fix: Windows 平台非项目根目录下脚本运行错误

### DIFF
--- a/embyToLocalPlayer_debug.bat
+++ b/embyToLocalPlayer_debug.bat
@@ -31,13 +31,13 @@ if "%PYTHON_VERSION:~0,6%" == "Python" (
 
 :SIX
 echo you have pressed six
-python utils/update.py
+python %~dp0/utils/update.py
 GOTO END
 
 
 :FIVE
 echo you have pressed five
-set mainCmd=python "%cd%\embyToLocalPlayer.py"
+set mainCmd=python "%~dp0\embyToLocalPlayer.py"
 echo %mainCmd%
 echo already copied, paste command is "Ctrl + V"
 echo %mainCmd%|clip
@@ -46,7 +46,7 @@ GOTO END
 
 :FOUR
 echo you have pressed four
-python utils/conf_helper.py
+python %~dp0/utils/conf_helper.py
 GOTO END
 
 
@@ -59,7 +59,7 @@ GOTO END
 :TWO
 echo you have pressed two
 set startupVbs="%APPDATA%\Microsoft\Windows\Start Menu\Programs\Startup\embyToLocalPlayer.vbs"
-set startupCmd=CreateObject("Wscript.Shell").Run """python"" ""%cd%\embyToLocalPlayer.py""" , 0, True
+set startupCmd=CreateObject("Wscript.Shell").Run """python"" ""%~dp0\embyToLocalPlayer.py""" , 0, True
 echo startupCmd=%startupCmd%
 echo startupVbs=%startupVbs%
 echo %startupCmd% > %startupVbs%
@@ -72,7 +72,7 @@ GOTO END
 
 :ONE
 echo you have pressed one
-python embyToLocalPlayer.py
+python %~dp0/embyToLocalPlayer.py
 GOTO END
 
 


### PR DESCRIPTION
**背景**：希望将脚本加入环境变量，以便随时通过命令运行

**问题**：在非项目根目录的路径运行会出现找不到 python 文件的错误

**复现**：在 `document` 文件夹下运行 `document/embyToLocalPlayer/embyToLocalPlayer_debug.bat` 脚本

```
~\Desktop\document
➜  .\embyToLocalPlayer\embyToLocalPlayer_debug.bat
Active code page: 65001
Python 3.9.12
C:\Users\admin\scoop\apps\miniconda3\current\python.exe
press a number
1: run in console
2: run in background and add to startup folder
3: open startup folder
4: path translate helper
5: copy script path to clipboard
6: update to latest version
press a number 1
you have pressed one
python: can't open file 'C:\Users\admin\Desktop\document\embyToLocalPlayer.py': [Errno 2] No such file or directory
all tasks are finished.
Press any key to continue . . .
```
**修复效果**：
```
~\Desktop\document
➜  .\embyToLocalPlayer\embyToLocalPlayer_debug.bat
Active code page: 65001
Python 3.9.12
C:\Users\admin\scoop\apps\miniconda3\current\python.exe
press a number
1: run in console
2: run in background and add to startup folder
3: open startup folder
4: path translate helper
5: copy script path to clipboard
6: update to latest version
press a number 1
you have pressed one
[03/13/24 17:42:36.4] ['Python path: C:\\Users\\_hide_user_\\scoop\\apps\\miniconda3\\current\\python.exe']
[03/13/24 17:42:36.4] ['ini path: C:\\Users\\_hide_user_\\Desktop\\document\\embyToLocalPlayer\\embyToLocalPlayer_config.ini']
[03/13/24 17:42:36.4] Windows-10-10.0.19045-SP0 Python-3.9.12
[03/13/24 17:42:39.2] C:\Users\_hide_user_\Desktop\document\embyToLocalPlayer\embyToLocalPlayer.py
[03/13/24 17:42:39.2] serving at 127.0.0.1:58000
```
其他选项已测试正常