### PR TITLE
去除Emby首页广告

### DIFF
--- a/user_script/embyToLocalPlayer.js
+++ b/user_script/embyToLocalPlayer.js
@@ -27,6 +27,10 @@
 
 (function () {
     'use strict';
+    // 去除首页 Discover Emby Premiere 广告
+    let adEle = document.querySelector('div.verticalSection.verticalSection-cards.section-appinfo.emby-scrollbuttons-scroller');
+    if (adEle) adEle.style.display = 'none';
+    
     let _crackFullPath = Boolean(localStorage.getItem('crackFullPath'));
     let _disableOpenFolder = Boolean(localStorage.getItem('disableOpenFolder'));
     let fistTime = true;


### PR DESCRIPTION
免费版Emby首页偶尔会出现这个Discover Emby Premiere的广告，有点烦，
![屏幕截图 2024-08-27 224207](https://github.com/user-attachments/assets/e8cc4de4-8746-420e-8018-3176270f3312)
就顺带写两行代码去一下广告，测了下应该没有误杀其他元素