### PR TITLE
mpv 添加--force-window=immediate

### DIFF
--- a/utils/players.py
+++ b/utils/players.py
@@ -348,6 +348,7 @@ def mpv_player_start(cmd, start_sec=None, sub_file=None, media_title=None, get_s
     if is_darwin:
         cmd.append('--focus-on-open')
     cmd.append(fr'--input-ipc-server={cmd_pipe}')
+    cmd.append('--force-window=immediate')
     cmd.append('--script-opts-append=autoload-disabled=yes')
     if configs.fullscreen:
         cmd.append('--fullscreen=yes')


### PR DESCRIPTION
服务端如果是外网的，带宽又不是很高的情况，启播的速度会很慢，可能要等个5秒以上窗口才会出现。

--force-window=immediate可以使窗口立即出现，在窗口下等待启播体验会更好。