### PR TITLE
增加macOS 下对 Movist Pro 的支持 

### DIFF
--- a/Jellyfin_Movist.py
+++ b/Jellyfin_Movist.py
@@ -5,7 +5,7 @@ import urllib.parse
 
 # 配置
 HOST = "localhost"  # 本地监听地址
-PORT = 58001       # 必须和用户脚本中的端口一致
+PORT = 58000       # 必须和用户脚本中的端口一致
 MOVIST_PRO_PATH = "/Applications/Movist Pro.app/Contents/MacOS/Movist Pro"  # Movist Pro 路径
 API_KEY = "替换为你的实际 API Key"
 

--- a/Jellyfin_Movist.py
+++ b/Jellyfin_Movist.py
@@ -1,26 +1,29 @@
 from http.server import BaseHTTPRequestHandler, HTTPServer
 import json
 import subprocess
-import urllib.parse
 
-# 配置
-HOST = "localhost"  # 本地监听地址
-PORT = 58000       # 必须和用户脚本中的端口一致
-MOVIST_PRO_PATH = "/Applications/Movist Pro.app/Contents/MacOS/Movist Pro"  # Movist Pro 路径
-API_KEY = "替换为你的实际 API Key"
+HOST = "localhost"
+PORT = 58000
+MOVIST_PRO_PATH = "/Applications/Movist Pro.app/Contents/MacOS/Movist Pro"
 
 class RequestHandler(BaseHTTPRequestHandler):
     def do_POST(self):
-        # 只处理 /embyToLocalPlayer/ 路径
+        print(f"\n=== 收到 POST 请求 ===")
+        print(f"路径: {self.path}")
+        for key, value in self.headers.items():
+            print(f"  {key}: {value}")
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        post_data = self.rfile.read(content_length)
+        print(f"\n原始数据内容:\n{post_data.decode('utf-8', errors='ignore')}")
+
+        # 只处理指定路径
         if not self.path.startswith("/embyToLocalPlayer/"):
             self.send_response(404)
             self.end_headers()
             self.wfile.write(b"Not Found")
             return
 
-        # 解析 JSON 数据
-        content_length = int(self.headers["Content-Length"])
-        post_data = self.rfile.read(content_length)
         try:
             data = json.loads(post_data.decode("utf-8"))
         except json.JSONDecodeError:
@@ -29,25 +32,30 @@ class RequestHandler(BaseHTTPRequestHandler):
             self.wfile.write(b"Invalid JSON")
             return
 
-        # 提取 playbackUrl
-        playback_url = data.get("playbackUrl")
-        if not playback_url:
+        # 从嵌套结构中提取播放服务器、token、UserId（用于构造 URL）
+        try:
+            server_address = data["ApiClient"]["_serverInfo"]["ManualAddress"]
+            access_token = data["ApiClient"]["_serverInfo"]["AccessToken"]
+            user_id = data["ApiClient"]["_serverInfo"]["UserId"]
+        except KeyError as e:
             self.send_response(400)
             self.end_headers()
-            self.wfile.write(b"Missing 'playbackUrl' in request")
+            self.wfile.write(f"Missing required field: {e}".encode("utf-8"))
             return
 
-        # 修改 playback_url：替换 PlaybackInfo 之后的内容
-        if "PlaybackInfo" in playback_url:
-            # 分割 URL，保留 PlaybackInfo 之前的部分
-            base_url = playback_url.split("PlaybackInfo")[0]
-            # 构造新的 Download URL
-            modified_url = f"{base_url}Download?api_key={API_KEY}"
-        else:
-            # 如果 URL 中没有 PlaybackInfo，直接使用原 URL（可选：也可以返回错误）
-            modified_url = playback_url
+        # 从 playbackData 中获取 item_id
+        try:
+            item_id = data["playbackData"]["MediaSources"][0]["Id"]
+        except (KeyError, IndexError, TypeError) as e:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Missing or invalid playbackData.MediaSources.Id")
+            return
 
-        # 调用 Movist Pro 播放修改后的 URL
+        modified_url = f"{server_address}/Items/{item_id}/Download?api_key={access_token}"
+
+        print(f"\n最终播放 URL: {modified_url}")
+
         try:
             subprocess.run([
                 "open", "-a", MOVIST_PRO_PATH, modified_url

--- a/Jellyfin_Movist.py
+++ b/Jellyfin_Movist.py
@@ -1,0 +1,70 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import subprocess
+import urllib.parse
+
+# 配置
+HOST = "localhost"  # 本地监听地址
+PORT = 58001       # 必须和用户脚本中的端口一致
+MOVIST_PRO_PATH = "/Applications/Movist Pro.app/Contents/MacOS/Movist Pro"  # Movist Pro 路径
+API_KEY = "替换为你的实际 API Key"
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        # 只处理 /embyToLocalPlayer/ 路径
+        if not self.path.startswith("/embyToLocalPlayer/"):
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+            return
+
+        # 解析 JSON 数据
+        content_length = int(self.headers["Content-Length"])
+        post_data = self.rfile.read(content_length)
+        try:
+            data = json.loads(post_data.decode("utf-8"))
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Invalid JSON")
+            return
+
+        # 提取 playbackUrl
+        playback_url = data.get("playbackUrl")
+        if not playback_url:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Missing 'playbackUrl' in request")
+            return
+
+        # 修改 playback_url：替换 PlaybackInfo 之后的内容
+        if "PlaybackInfo" in playback_url:
+            # 分割 URL，保留 PlaybackInfo 之前的部分
+            base_url = playback_url.split("PlaybackInfo")[0]
+            # 构造新的 Download URL
+            modified_url = f"{base_url}Download?api_key={API_KEY}"
+        else:
+            # 如果 URL 中没有 PlaybackInfo，直接使用原 URL（可选：也可以返回错误）
+            modified_url = playback_url
+
+        # 调用 Movist Pro 播放修改后的 URL
+        try:
+            subprocess.run([
+                "open", "-a", MOVIST_PRO_PATH, modified_url
+            ], check=True)
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"Playback started with Movist Pro")
+        except subprocess.CalledProcessError as e:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(f"Failed to play: {str(e)}".encode("utf-8"))
+
+if __name__ == "__main__":
+    server = HTTPServer((HOST, PORT), RequestHandler)
+    print(f"Server running on http://{HOST}:{PORT} (Press Ctrl+C to stop)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()
+        print("Server stopped")

--- a/Jellyfin_Movist_Local_Path.py
+++ b/Jellyfin_Movist_Local_Path.py
@@ -1,0 +1,80 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import json
+import subprocess
+
+HOST = "localhost"
+PORT = 58000
+MOVIST_PRO_PATH = "/Applications/Movist Pro.app/Contents/MacOS/Movist Pro"
+
+# 路径替换关系：
+# "Jellyfin 中的媒体库文件夹": "本机的媒体库文件夹"
+
+PATH_REPLACEMENTS = {
+    "/NAS": "/Volumes/share"
+}
+
+class RequestHandler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        if not self.path.startswith("/embyToLocalPlayer/"):
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b"Not Found")
+            return
+
+        content_length = int(self.headers.get("Content-Length", 0))
+        post_data = self.rfile.read(content_length)
+
+        try:
+            data = json.loads(post_data.decode("utf-8"))
+        except json.JSONDecodeError:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Invalid JSON")
+            return
+
+        try:
+            server_address = data["ApiClient"]["_serverInfo"]["ManualAddress"]
+            access_token = data["ApiClient"]["_serverInfo"]["AccessToken"]
+            user_id = data["ApiClient"]["_serverInfo"]["UserId"]
+        except KeyError as e:
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(f"Missing required field: {e}".encode("utf-8"))
+            return
+
+        try:
+            media_source = data["playbackData"]["MediaSources"][0]
+            item_id = media_source["Id"]
+            file_path = media_source["Path"]
+        except (KeyError, IndexError, TypeError):
+            self.send_response(400)
+            self.end_headers()
+            self.wfile.write(b"Missing or invalid playbackData.MediaSources")
+            return
+
+        replaced_path = file_path
+        for old_prefix, new_prefix in PATH_REPLACEMENTS.items():
+            if replaced_path.startswith(old_prefix):
+                replaced_path = replaced_path.replace(old_prefix, new_prefix, 1)
+                break
+
+        try:
+            subprocess.run([
+                "open", "-a", MOVIST_PRO_PATH, replaced_path
+            ], check=True)
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"Playback started with Movist Pro")
+        except subprocess.CalledProcessError as e:
+            self.send_response(500)
+            self.end_headers()
+            self.wfile.write(f"Failed to play: {str(e)}".encode("utf-8"))
+
+
+if __name__ == "__main__":
+    server = HTTPServer((HOST, PORT), RequestHandler)
+    print(f"Server running on http://{HOST}:{PORT} (Press Ctrl+C to stop)")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        server.server_close()

--- a/utils/bangumi_sync.py
+++ b/utils/bangumi_sync.py
@@ -142,7 +142,7 @@ def search_and_sync(bgm, title, ori_title, premiere_date, season_num, ep_nums, e
         logger.info('bgm: try math by ep air date')
         if eps_data[0].get('item_id'):  # 解析过的，不含上映时间
             emby_ids = [i['item_id'] for i in eps_data]
-            eps_data = emby.get_items(ids=','.join(emby_ids))['Items']
+            eps_data = emby.get_items(ids=emby_ids)['Items']
         emby_dates = [i['PremiereDate'] for i in eps_data]
         bgm_sea_id, bgm_ep_ids = bgm.get_target_season_episode_id(
             subject_id=subject_id, target_season=season_num, target_ep=ep_nums,

--- a/utils/emby_api.py
+++ b/utils/emby_api.py
@@ -111,10 +111,10 @@ class EmbyApi:
         return res
 
     def get_items(self, genre='', types='Movie,Series,Video', fields: typing.Union[list, str] = None, start_index=0,
-                  ids=None, limit=50, parent_id=None,
+                  ids: typing.Union[list, str] = None, limit=50, parent_id=None,
                   sort_by='DateCreated,SortName',
                   recursive=True, ext_params: dict = None, filters=None, by_user=False):
-        # 注意默认不包含 Episode。同时 Episode 需要 ext_params={'HasTmdbId': None}。
+        # 注意默认不包含 Episode。同时 Episode 需要 ext_params={'HasTmdbId': None}。IncludeItemTypes = None
         fields = fields or self._default_fields
         fields = fields if isinstance(fields, str) else ','.join(fields)
         params = {
@@ -132,6 +132,11 @@ class EmbyApi:
         if genre:
             params.update({'GenreIds': self.get_genre_id(genre)})
         if ids:
+            params.update({'HasTmdbId': None,
+                           'IncludeItemTypes': None})
+            if isinstance(ids, (list, tuple)):
+                ids = map(str, ids)
+                ids = ','.join(ids)
             params.update({'Ids': ids})
         if parent_id:
             params.update({'ParentId': parent_id})

--- a/utils/others/etlp_run_via_screen.command
+++ b/utils/others/etlp_run_via_screen.command
@@ -21,5 +21,6 @@ if [ $(screen -ls | grep -c $screen_name) -ne 0 ]; then
 fi
 
 screen -dmS $screen_name
-screen -x $screen_name -p 0 -X stuff "python3 embyToLocalPlayer.py"
+# screen -x $screen_name -p 0 -X stuff "python3 embyToLocalPlayer.py"
+screen -x $screen_name -p 0 -X stuff "python3 Jellyfin_Movist.py"
 screen -x $screen_name -p 0 -X stuff $'\n'

--- a/utils/tools.py
+++ b/utils/tools.py
@@ -340,7 +340,7 @@ def main_ep_intro_time(main_ep_info):
 
 
 def show_version_info(extra_data):
-    py_script_version = '2025.02.08'
+    py_script_version = '2025.05.21'
     gm_info = extra_data.get('gmInfo')
     user_agent = extra_data.get('userAgent')
     if not gm_info:


### PR DESCRIPTION
说明：
在 macOS 系统中，Movist Pro 对部分视频格式具备更佳的解码效果与播放稳定性。为提升播放体验，本次提交新增对 Movist Pro 的支持。

可实现的功能：
拦截媒体播放请求，并将播放信息发送至本地服务器（127.0.0.1:58000），由 Movist Pro 进行播放处理。

测试情况：
已在以下环境下测试通过，运行稳定、兼容性良好：

macOS 13.7.5

Movist Pro 2.13.0

Jellyfin 10.10.7

其他说明：
使用前，请将 Jellyfin 的 API Key 填入 Jellyfin_Movist.py 文件中对应位置。