### PR TITLE
mpv播放列表取消设置`--title`参数

### DIFF
--- a/utils/players.py
+++ b/utils/players.py
@@ -202,7 +202,7 @@ def playlist_add_mpv(mpv: MPV, data, eps_data=None, limit=10):
                 chap_cmd = ''
 
             try:
-                options = (f'title="{media_title}",force-media-title="{media_title}"'
+                options = (f'force-media-title="{media_title}"'
                            f',osd-playing-msg="{media_title}",start=0{sub_cmd}{chap_cmd}')
                 if insert:
                     mpv_cmd = ['loadfile', ep['media_path'], 'insert-at', '0', options]


### PR DESCRIPTION
起播的首集没有`--title`参数，播放列表也不需要，有`--force-media-title`设置媒体标题已经足够了。

`--title`设置的是窗口标题栏，默认是媒体标题后面拼上 - mpv后缀
https://github.com/mpv-player/mpv/blob/18defc8530caf7694b132a501e9c34476d4cef80/options/options.c#L984

使用时偶然发现标题栏怎么少了 - mpv后缀，然后发现给强制覆盖了，
用户也可能在标题栏自定义显示其他内容，不应该去覆盖它，
例如: https://github.com/dyphire/mpv-config/blob/073e0bfb5ed6ba54b5973a1cfe8c7b59bda04e81/mpv.conf#L63