### PR TITLE
adapt: include ok button text `明白`

### DIFF
--- a/user_script/embyToLocalPlayer.user.js
+++ b/user_script/embyToLocalPlayer.user.js
@@ -166,7 +166,7 @@
         let state = false;
         for (let index = 0; index < okButtonList.length; index++) {
             const element = okButtonList[index];
-            if (element.textContent.search(/(了解|好的|知道|Got It)/) != -1) {
+            if (element.textContent.search(/(了解|好的|知道|明白|Got It)/) != -1) {
                 element.click();
                 if (isHidden(element)) { continue; }
                 state = true;


### PR DESCRIPTION
RT，
最新的emby 4.9.1.21测试版报错弹窗按钮的文字变成 `明白` 。

```html
<div class="focuscontainer dialog dialog-animated dialog-fullscreen-lowres dialog-fullscreen-lowres-autoheight centeredDialog dialog-swipe-close formDialog justify-content-center alertDialog opened afterOpened" data-lockscroll="true" data-autofocus="true" data-removeonclose="true"><div class="formDialogHeader justify-content-center">
    <h3 class="formDialogHeaderTitle">播放错误</h3>
</div>

<div is="emby-scroller" data-horizontal="false" data-focusscroll="true" class="formDialogContent emby-scroller no-grow dialog-scrollY scrollY scrollFrameY flex-direction-column" style="width:100%;">
    <div class="scrollSlider dialogContentInner dialogContentInner-normalbottompadding dialog-content-centered padded-left padded-right padded-top scrollSliderY" style="text-align: center;">处理请求时出错。请稍后再试。</div>
</div>

<div class="formDialogFooter formDialogFooter-clear formDialogFooter-flex"><button is="emby-button" type="button" class="btnOption raised formDialogFooterItem formDialogFooterItem-autosize emby-button button-hoverable" data-id="ok"><span>明白</span></button></div></div>
```