### PR TITLE
修复mpv意外将内封字幕提取为外挂字幕的问题

### DIFF
--- a/utils/data_parser.py
+++ b/utils/data_parser.py
@@ -184,7 +184,7 @@ def parse_received_data_emby(received_data):
     sub_index, sub_inner_idx, sub_dict = subtitle_checker(media_streams, sub_index, mount_disk_mode, log=True)
     sub_jellyfin_str = '' if is_emby \
         else f'{item_id[:8]}-{item_id[8:12]}-{item_id[12:16]}-{item_id[16:20]}-{item_id[20:]}/'
-    if sub_dict:
+    if sub_dict and sub_inner_idx != 0:
         sub_emby_str = f'/{media_source_id}' if is_emby else ''
         # sub_data = media_source_info['MediaStreams'][sub_index]
         fallback_sub = f'{extra_str}/videos/{sub_jellyfin_str}{item_id}{sub_emby_str}/Subtitles' \
@@ -719,7 +719,7 @@ def list_episodes(data: dict):
         sub_index, sub_inner_idx, sub_dict = subtitle_checker(media_streams, need_check_inner_sub, mount_disk_mode)
 
         sub_file = None
-        if sub_dict:
+        if sub_dict and sub_inner_idx != 0:
             sub_file = f'{scheme}://{netloc}/Videos/{item_id}/{source_info["Id"]}/Subtitles' \
                        f'/{sub_dict["Index"]}/Stream{os.path.splitext(sub_dict["Path"])[-1]}'
 


### PR DESCRIPTION
kjtsune/embyToLocalPlayer@283f4a794f0324b5ba79c59b9137413be2b356f2 中引入的问题,
在选中内封字幕的情况下，还意外的将它的外挂链接也加进去了。

在 sub_inner_idx 有效时 sub_file 应该忽略。